### PR TITLE
Fix: Remove trailing slash from linkedin url

### DIFF
--- a/data/en/author.yaml
+++ b/data/en/author.yaml
@@ -9,7 +9,7 @@ contactInfo:
   # email: "no@example.com"
   # phone: "+0123456789"
   github: https://github.com/Saberoni
-  linkedin: https://www.linkedin.com/in/matt-sulley-4a2b622a9/
+  linkedin: https://www.linkedin.com/in/matt-sulley-4a2b622a9
 
 # some summary about what you do
 summary:

--- a/data/en/author.yaml
+++ b/data/en/author.yaml
@@ -8,8 +8,8 @@ image: "images/author/pd-red.png"
 contactInfo:
   # email: "no@example.com"
   # phone: "+0123456789"
-  github: https://github.com/Saberoni
-  linkedin: https://www.linkedin.com/in/matt-sulley-4a2b622a9
+  github: Saberoni
+  linkedin: matt-sulley-4a2b622a9
 
 # some summary about what you do
 summary:

--- a/data/en/sections/about.yaml
+++ b/data/en/sections/about.yaml
@@ -45,7 +45,7 @@ socialLinks:
 
 - name: LinkedIn
   icon: "fab fa-linkedin"
-  url: "https://www.linkedin.com/in/matt-sulley-4a2b622a9/"
+  url: "https://www.linkedin.com/in/matt-sulley-4a2b622a9"
 
 
 # Show your badges


### PR DESCRIPTION
fix broken urls