### PR TITLE
Fix: ucf pages baseurl problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,12 @@ Pages will automatically build and publish preview pages on pull requests, I hav
 | feat | :white_check_mark: |
 | fix | :white_check_mark: |
 | bug | :white_check_mark: |
+
+
+## Local Development
+
+1. Open repo in devcontainer
+2. run `hugo mod tidy`
+3. run `hugo mod npm pack`
+4. run `npm install`
+5. run local server `hugo server -w`

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,4 +1,4 @@
-baseURL: https://myquestlog.pages.dev/
+baseURL: "/"
 languageCode: en-gb
 title: Matt Sulley, a Resume
 


### PR DESCRIPTION
Cloudflare Pages baseurl ends up using the commit url so we will try to fix it